### PR TITLE
Ensures pf9-demo container image always pulled from registry

### DIFF
--- a/kubernetes/pf9-demo/pf9-demo.yaml
+++ b/kubernetes/pf9-demo/pf9-demo.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       containers:
       - image: pf9dockerhub/pf9-demo
+        imagePullPolicy: Always
         name: demo
         ports:
         - containerPort: 80


### PR DESCRIPTION
- may resolve a stale container image issue sometimes seen during
  the kitten/nautilus demo
- for details see
  http://kubernetes.io/docs/user-guide/pods/multi-container/
